### PR TITLE
feat: core modifications for v1 DEX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Uniswap V3
+# T-REX DEX Smart Contracts (v1)
+
+## Forked from Uniswap V3
 
 [![Lint](https://github.com/Uniswap/uniswap-v3-core/actions/workflows/lint.yml/badge.svg)](https://github.com/Uniswap/uniswap-v3-core/actions/workflows/lint.yml)
 [![Tests](https://github.com/Uniswap/uniswap-v3-core/actions/workflows/tests.yml/badge.svg)](https://github.com/Uniswap/uniswap-v3-core/actions/workflows/tests.yml)

--- a/audits/tob/contracts/crytic/echidna/E2E_mint_burn.sol
+++ b/audits/tob/contracts/crytic/echidna/E2E_mint_burn.sol
@@ -75,11 +75,9 @@ contract E2E_mint_burn {
         require(burnAmount > 0);
     }
 
-    function _getRandomPositionIdxAndBurnAmount(uint128 _seed)
-        internal
-        view
-        returns (uint128 positionIdx, uint128 burnAmount)
-    {
+    function _getRandomPositionIdxAndBurnAmount(
+        uint128 _seed
+    ) internal view returns (uint128 positionIdx, uint128 burnAmount) {
         positionIdx = _getRandomPositionIdx(_seed, positions.length);
         burnAmount = _getRandomBurnAmount(_seed, positions[positionIdx].amount);
     }
@@ -283,32 +281,22 @@ contract E2E_mint_burn {
         int24 _poolTickSpacing,
         uint24 _poolTickCount,
         int24 _poolMaxTick
-    )
-        public
-        view
-        returns (
-            int24 tickLower,
-            int24 tickUpper,
-            uint128 amount
-        )
-    {
+    ) public view returns (int24 tickLower, int24 tickUpper, uint128 amount) {
         (tickLower, tickUpper) = forgePosition(_seed, _poolTickSpacing, _poolTickCount, _poolMaxTick);
         amount = _seed;
     }
 
-    function viewBurnRandomPositionIdx(uint128 _seed, uint128 _positionsCount)
-        public
-        view
-        returns (uint128 positionIdx)
-    {
+    function viewBurnRandomPositionIdx(
+        uint128 _seed,
+        uint128 _positionsCount
+    ) public view returns (uint128 positionIdx) {
         positionIdx = _getRandomPositionIdx(_seed, _positionsCount);
     }
 
-    function viewBurnRandomPositionBurnAmount(uint128 _seed, uint128 _positionAmount)
-        public
-        view
-        returns (uint128 burnAmount)
-    {
+    function viewBurnRandomPositionBurnAmount(
+        uint128 _seed,
+        uint128 _positionAmount
+    ) public view returns (uint128 burnAmount) {
         burnAmount = _getRandomBurnAmount(_seed, _positionAmount);
     }
 
@@ -319,20 +307,8 @@ contract E2E_mint_burn {
     //
 
     function forgePoolParams(uint128 _seed) internal view returns (PoolParams memory _poolParams) {
-        //
-        // decide on one of the three fees, and corresponding tickSpacing
-        //
-        if (_seed % 3 == 0) {
-            _poolParams.fee = uint24(500);
-            _poolParams.tickSpacing = int24(10);
-        } else if (_seed % 3 == 1) {
-            _poolParams.fee = uint24(3000);
-            _poolParams.tickSpacing = int24(60);
-        } else if (_seed % 3 == 2) {
-            _poolParams.fee = uint24(10000);
-            _poolParams.tickSpacing = int24(2000);
-        }
-
+        _poolParams.fee = uint24(5000);
+        _poolParams.tickSpacing = int24(100);
         _poolParams.maxTick = (int24(887272) / _poolParams.tickSpacing) * _poolParams.tickSpacing;
         _poolParams.minTick = -_poolParams.maxTick;
         _poolParams.tickCount = uint24(_poolParams.maxTick / _poolParams.tickSpacing);
@@ -382,11 +358,18 @@ contract E2E_mint_burn {
 
     function test_mint(uint128 _amount) public {
         if (!inited) _init(_amount);
-        (int24 _tL, int24 _tU) =
-            forgePosition(_amount, poolParams.tickSpacing, poolParams.tickCount, poolParams.maxTick);
+        (int24 _tL, int24 _tU) = forgePosition(
+            _amount,
+            poolParams.tickSpacing,
+            poolParams.tickCount,
+            poolParams.maxTick
+        );
 
-        (UniswapMinter.MinterStats memory bfre, UniswapMinter.MinterStats memory aftr) =
-            minter.doMint(_tL, _tU, _amount);
+        (UniswapMinter.MinterStats memory bfre, UniswapMinter.MinterStats memory aftr) = minter.doMint(
+            _tL,
+            _tU,
+            _amount
+        );
         storeUsedTicks(_tL, _tU);
 
         check_mint_invariants(_tL, _tU, bfre, aftr);

--- a/audits/tob/contracts/crytic/echidna/E2E_swap.sol
+++ b/audits/tob/contracts/crytic/echidna/E2E_swap.sol
@@ -65,11 +65,9 @@ contract E2E_swap {
     //
     //
 
-    function get_random_zeroForOne_priceLimit(int256 _amountSpecified)
-        internal
-        view
-        returns (uint160 sqrtPriceLimitX96)
-    {
+    function get_random_zeroForOne_priceLimit(
+        int256 _amountSpecified
+    ) internal view returns (uint160 sqrtPriceLimitX96) {
         // help echidna a bit by calculating a valid sqrtPriceLimitX96 using the amount as random seed
         (uint160 currentPrice, , , , , , ) = pool.slot0();
         uint160 minimumPrice = TickMath.MIN_SQRT_RATIO;
@@ -80,11 +78,9 @@ contract E2E_swap {
             );
     }
 
-    function get_random_oneForZero_priceLimit(int256 _amountSpecified)
-        internal
-        view
-        returns (uint160 sqrtPriceLimitX96)
-    {
+    function get_random_oneForZero_priceLimit(
+        int256 _amountSpecified
+    ) internal view returns (uint160 sqrtPriceLimitX96) {
         // help echidna a bit by calculating a valid sqrtPriceLimitX96 using the amount as random seed
         (uint160 currentPrice, , , , , , ) = pool.slot0();
         uint160 maximumPrice = TickMath.MAX_SQRT_RATIO;
@@ -189,11 +185,9 @@ contract E2E_swap {
     //
     //
 
-    function viewRandomInit(uint128 _seed)
-        public
-        view
-        returns (PoolParams memory poolParams, PoolPositions memory poolPositions)
-    {
+    function viewRandomInit(
+        uint128 _seed
+    ) public view returns (PoolParams memory poolParams, PoolPositions memory poolPositions) {
         poolParams = forgePoolParams(_seed);
         poolPositions = forgePoolPositions(_seed, poolParams.tickSpacing, poolParams.tickCount, poolParams.maxTick);
     }
@@ -205,20 +199,8 @@ contract E2E_swap {
     //
 
     function forgePoolParams(uint128 _seed) internal view returns (PoolParams memory poolParams) {
-        //
-        // decide on one of the three fees, and corresponding tickSpacing
-        //
-        if (_seed % 3 == 0) {
-            poolParams.fee = uint24(500);
-            poolParams.tickSpacing = int24(10);
-        } else if (_seed % 3 == 1) {
-            poolParams.fee = uint24(3000);
-            poolParams.tickSpacing = int24(60);
-        } else if (_seed % 3 == 2) {
-            poolParams.fee = uint24(10000);
-            poolParams.tickSpacing = int24(2000);
-        }
-
+        poolParams.fee = uint24(5000);
+        poolParams.tickSpacing = int24(100);
         poolParams.maxTick = (int24(887272) / poolParams.tickSpacing) * poolParams.tickSpacing;
         poolParams.minTick = -poolParams.maxTick;
         poolParams.tickCount = uint24(poolParams.maxTick / poolParams.tickSpacing);
@@ -360,8 +342,11 @@ contract E2E_swap {
         uint160 sqrtPriceLimitX96 = get_random_zeroForOne_priceLimit(_amount);
         // console.log('sqrtPriceLimitX96 = %s', sqrtPriceLimitX96);
 
-        (UniswapSwapper.SwapperStats memory bfre, UniswapSwapper.SwapperStats memory aftr) =
-            swapper.doSwap(true, _amountSpecified, sqrtPriceLimitX96);
+        (UniswapSwapper.SwapperStats memory bfre, UniswapSwapper.SwapperStats memory aftr) = swapper.doSwap(
+            true,
+            _amountSpecified,
+            sqrtPriceLimitX96
+        );
 
         check_swap_invariants(
             bfre.tick,
@@ -394,8 +379,11 @@ contract E2E_swap {
         uint160 sqrtPriceLimitX96 = get_random_oneForZero_priceLimit(_amount);
         // console.log('sqrtPriceLimitX96 = %s', sqrtPriceLimitX96);
 
-        (UniswapSwapper.SwapperStats memory bfre, UniswapSwapper.SwapperStats memory aftr) =
-            swapper.doSwap(false, _amountSpecified, sqrtPriceLimitX96);
+        (UniswapSwapper.SwapperStats memory bfre, UniswapSwapper.SwapperStats memory aftr) = swapper.doSwap(
+            false,
+            _amountSpecified,
+            sqrtPriceLimitX96
+        );
 
         check_swap_invariants(
             bfre.tick,
@@ -428,8 +416,11 @@ contract E2E_swap {
         uint160 sqrtPriceLimitX96 = get_random_zeroForOne_priceLimit(_amount);
         // console.log('sqrtPriceLimitX96 = %s', sqrtPriceLimitX96);
 
-        (UniswapSwapper.SwapperStats memory bfre, UniswapSwapper.SwapperStats memory aftr) =
-            swapper.doSwap(true, _amountSpecified, sqrtPriceLimitX96);
+        (UniswapSwapper.SwapperStats memory bfre, UniswapSwapper.SwapperStats memory aftr) = swapper.doSwap(
+            true,
+            _amountSpecified,
+            sqrtPriceLimitX96
+        );
 
         check_swap_invariants(
             bfre.tick,
@@ -462,8 +453,11 @@ contract E2E_swap {
         uint160 sqrtPriceLimitX96 = get_random_oneForZero_priceLimit(_amount);
         // console.log('sqrtPriceLimitX96 = %s', sqrtPriceLimitX96);
 
-        (UniswapSwapper.SwapperStats memory bfre, UniswapSwapper.SwapperStats memory aftr) =
-            swapper.doSwap(false, _amountSpecified, sqrtPriceLimitX96);
+        (UniswapSwapper.SwapperStats memory bfre, UniswapSwapper.SwapperStats memory aftr) = swapper.doSwap(
+            false,
+            _amountSpecified,
+            sqrtPriceLimitX96
+        );
 
         check_swap_invariants(
             bfre.tick,

--- a/audits/tob/contracts/crytic/echidna/Setup.sol
+++ b/audits/tob/contracts/crytic/echidna/Setup.sol
@@ -42,11 +42,7 @@ contract SetupTokens {
     }
 
     // mint either token0 or token1 to a chosen account
-    function mintTo(
-        uint256 _tokenIdx,
-        address _recipient,
-        uint256 _amount
-    ) public {
+    function mintTo(uint256 _tokenIdx, address _recipient, uint256 _amount) public {
         require(_tokenIdx == 0 || _tokenIdx == 1, 'invalid token idx');
         if (_tokenIdx == 0) tokenSetup0.mintTo(_recipient, _amount);
         if (_tokenIdx == 1) tokenSetup1.mintTo(_recipient, _amount);
@@ -59,9 +55,7 @@ contract SetupUniswap {
     TestERC20 token1;
 
     // will create the following enabled fees and corresponding tickSpacing
-    // fee 500   + tickSpacing 10
-    // fee 3000  + tickSpacing 60
-    // fee 10000 + tickSpacing 200
+    // fee 5000   + tickSpacing 100
     UniswapV3Factory factory;
 
     constructor(TestERC20 _token0, TestERC20 _token1) public {
@@ -98,25 +92,15 @@ contract UniswapMinter {
         pool = _pool;
     }
 
-    function uniswapV3MintCallback(
-        uint256 amount0Owed,
-        uint256 amount1Owed,
-        bytes calldata data
-    ) external {
+    function uniswapV3MintCallback(uint256 amount0Owed, uint256 amount1Owed, bytes calldata data) external {
         if (amount0Owed > 0) token0.transfer(address(pool), amount0Owed);
         if (amount1Owed > 0) token1.transfer(address(pool), amount1Owed);
     }
 
-    function getTickLiquidityVars(int24 _tickLower, int24 _tickUpper)
-        internal
-        view
-        returns (
-            uint128,
-            int128,
-            uint128,
-            int128
-        )
-    {
+    function getTickLiquidityVars(
+        int24 _tickLower,
+        int24 _tickUpper
+    ) internal view returns (uint128, int128, uint128, int128) {
         (uint128 tL_liqGross, int128 tL_liqNet, , ) = pool.ticks(_tickLower);
         (uint128 tU_liqGross, int128 tU_liqNet, , ) = pool.ticks(_tickUpper);
         return (tL_liqGross, tL_liqNet, tU_liqGross, tU_liqNet);
@@ -171,11 +155,7 @@ contract UniswapSwapper {
         pool = _pool;
     }
 
-    function uniswapV3SwapCallback(
-        int256 amount0Delta,
-        int256 amount1Delta,
-        bytes calldata data
-    ) external {
+    function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external {
         if (amount0Delta > 0) token0.transfer(address(pool), uint256(amount0Delta));
         if (amount1Delta > 0) token1.transfer(address(pool), uint256(amount1Delta));
     }

--- a/contracts/UniswapV3Factory.sol
+++ b/contracts/UniswapV3Factory.sol
@@ -18,7 +18,6 @@ contract UniswapV3Factory is IUniswapV3Factory, UniswapV3PoolDeployer, NoDelegat
     mapping(uint24 => int24) public override feeAmountTickSpacing;
     /// @inheritdoc IUniswapV3Factory
     mapping(address => mapping(address => mapping(uint24 => address))) public override getPool;
-    mapping(uint24 => bool) public feeAmountEnabled; // T-REX (fee-tier mod)
 
     constructor() {
         owner = msg.sender;
@@ -34,6 +33,7 @@ contract UniswapV3Factory is IUniswapV3Factory, UniswapV3PoolDeployer, NoDelegat
         address tokenB,
         uint24 fee
     ) external override noDelegateCall returns (address pool) {
+        require(msg.sender == owner); // T-REX (limit pool creation mod)
         require(tokenA != tokenB);
         (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
         require(token0 != address(0));

--- a/contracts/UniswapV3Factory.sol
+++ b/contracts/UniswapV3Factory.sol
@@ -18,17 +18,14 @@ contract UniswapV3Factory is IUniswapV3Factory, UniswapV3PoolDeployer, NoDelegat
     mapping(uint24 => int24) public override feeAmountTickSpacing;
     /// @inheritdoc IUniswapV3Factory
     mapping(address => mapping(address => mapping(uint24 => address))) public override getPool;
+    mapping(uint24 => bool) public feeAmountEnabled; // T-REX (fee-tier mod)
 
     constructor() {
         owner = msg.sender;
         emit OwnerChanged(address(0), msg.sender);
 
-        feeAmountTickSpacing[500] = 10;
-        emit FeeAmountEnabled(500, 10);
-        feeAmountTickSpacing[3000] = 60;
-        emit FeeAmountEnabled(3000, 60);
-        feeAmountTickSpacing[10000] = 200;
-        emit FeeAmountEnabled(10000, 200);
+        feeAmountTickSpacing[5000] = 100; // T-REX (fee-tier mod)
+        emit FeeAmountEnabled(5000, 100); // T-REX (fee-tier mod)
     }
 
     /// @inheritdoc IUniswapV3Factory

--- a/package.json
+++ b/package.json
@@ -1,20 +1,14 @@
 {
-  "name": "@uniswap/v3-core",
-  "description": "🦄 Core smart contracts of Uniswap V3",
+  "name": "trex-dex-contracts",
+  "description": "Core DEX smart contracts",
   "license": "BUSL-1.1",
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.1",
-  "homepage": "https://uniswap.org",
-  "keywords": [
-    "uniswap",
-    "core",
-    "v3"
-  ],
+  "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Uniswap/uniswap-v3-core"
+    "url": "https://github.com/Tempestas-DeFi/trex-dex-contracts"
   },
   "files": [
     "contracts/interfaces",

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -1,9 +1,9 @@
 import bn from 'bignumber.js'
 import { BigNumber, BigNumberish, constants, Contract, ContractTransaction, utils, Wallet } from 'ethers'
-import { TestUniswapV3Callee } from '../../typechain/TestUniswapV3Callee'
-import { TestUniswapV3Router } from '../../typechain/TestUniswapV3Router'
 import { MockTimeUniswapV3Pool } from '../../typechain/MockTimeUniswapV3Pool'
 import { TestERC20 } from '../../typechain/TestERC20'
+import { TestUniswapV3Callee } from '../../typechain/TestUniswapV3Callee'
+import { TestUniswapV3Router } from '../../typechain/TestUniswapV3Router'
 
 export const MaxUint128 = BigNumber.from(2).pow(128).sub(1)
 
@@ -19,12 +19,14 @@ export const MIN_SQRT_RATIO = BigNumber.from('4295128739')
 export const MAX_SQRT_RATIO = BigNumber.from('1461446703485210103287273052203988822378723970342')
 
 export enum FeeAmount {
+  DEFAULT = 5000,
   LOW = 500,
   MEDIUM = 3000,
   HIGH = 10000,
 }
 
 export const TICK_SPACINGS: { [amount in FeeAmount]: number } = {
+  [FeeAmount.DEFAULT]: 100,
   [FeeAmount.LOW]: 10,
   [FeeAmount.MEDIUM]: 60,
   [FeeAmount.HIGH]: 200,


### PR DESCRIPTION
**WORK IN PROGRESS**
---
This PR includes the following core changes to the UniSwap v3 DEX smart contracts:
 - [x] [Collapse the three fee tiers into one (`0.5%`)](https://github.com/dennisfurrer/trex-dex-contracts/pull/1/commits/870500302b9d58d4f9d55478ecd554178ee54a3e)
   - Do we need the ability to create new / delete fee tiers?
   - [ ] @dennisfurrer come back to this to ensure the fee splitting logic is clear (between LPs and the protocol) -> maybe this also needs to be configurable (?)
   - [ ] @dennisfurrer come back to remove tests related to deprecated fee tiers & fix remaining
 - [x] [Limit pool creation to only the contract owners](https://github.com/dennisfurrer/trex-dex-contracts/pull/1/commits/df0acd99a3858357023eb982453861cc59c018f8)
   - [ ] @dennisfurrer Validate the ownership concept implemented in the smart contracts meets the requirements (supports metatxs, we will move ownership to a gnosis multi-sig operated with ledger hardware wallets)